### PR TITLE
feat: add terraform modules for proxmox and libvirt

### DIFF
--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,66 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/bpg/proxmox" {
+  version     = "0.81.0"
+  constraints = ">= 0.40.0"
+  hashes = [
+    "h1:7UFdTwY2mo034bhUEaW/femfDRYyhfYgSb9sDlrVczI=",
+    "zh:0112509b8b5215bec18de5da5d1b9e363e5174daae2b27d7d5f6711ff2039bcf",
+    "zh:150804842c6e23fd4b582ceaeefa3820dd256ceab5d594b585facdc5eeeed537",
+    "zh:29a71a65b6085ab5588b39b58ae63ea78cb6bcd2a5e63ac3508e61022a1c6bef",
+    "zh:3f76a2ffb257416f2fc44ec5fb4e02f32e8fe6581dda384cb093a733208fcc75",
+    "zh:600b13c2ca87be3ff111cf0479c3b91a7daba46a471603014feedacade5cecd0",
+    "zh:612148285fea24797174073d28164462efab0c18b6a21de4d26d7312f8a95126",
+    "zh:6f2ea6fbdcf0f5723f5d54a42ea944dd706c57aed3ceac6889bbb4bb6250bcc2",
+    "zh:7f2e746e9185f720e0d0c08667ee32f97ad767ae8d9a00a9781fcb0a172f4004",
+    "zh:7f2ee16c903c22695fd88134a7b4980495cc04a6d453985fcad6511bd5495988",
+    "zh:7f97014c51b9ea8a035455ba05f2ec81f8e00a0b26aad481ba1203a91c958d09",
+    "zh:9a80d2a7d0a51b085cba216c0b75a7a03a2a8992ec2bdc0bb928a832586133ed",
+    "zh:c97a95a648551488d48281d6ee1ff71f6a6b6b449ca71d1afc88fa1d134a8a5d",
+    "zh:d756e670e39db97a347174404c1230ae938a8f57f4a33f59b893e362db4c14c3",
+    "zh:d7b12cff6236c71bf3807286c6799b04f8b0068b25a71d1b213d85c9405d93ca",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}
+
+provider "registry.terraform.io/dmacvicar/libvirt" {
+  version     = "0.8.3"
+  constraints = ">= 0.7.0"
+  hashes = [
+    "h1:Tttxr3E9O75MM+dDmq5sYHQEw29PwtIj+XDj/5drdfE=",
+    "zh:06ff0169beafd1891dc5a30616983abd32004a4f570d1d3dbb5851d84bd1c007",
+    "zh:2dbdd726d0987cda73b56ecdfbcb98a67485e86a7a44aec976c0081b7239d89d",
+    "zh:2e195a7bbdfcc13c45460571a5ba848a5c1e746b477c8381058767560f0ac93b",
+    "zh:3952da13080018c5aec498b73e343c4c22ad884afb8c983138fb7255617aa991",
+    "zh:478841bcf57df938726ddb90f55c7953fad09db4f6348747519afe7fc84b403b",
+    "zh:53bce78b03a82c4782acfe1f32c2b46a68fa5fb2fb90d4a5392c90b436b44244",
+    "zh:5c157f23e9768c67cddf9e847a571adca441607cb5adfb96dbfdd626ceadf92c",
+    "zh:6bc78d631959fb695664966851308e140c38f3f5cf648dd89756320c2d91765d",
+    "zh:8605d7d6915190836802654920a8eea3d751ae437273c4f4476dc0ebb9167a1d",
+    "zh:8b66a22b97331c2a56aed092fd39152d06ad957fd4810aa3f0c4ade0f9b15755",
+    "zh:92586a47a04082f70bb33f722672127a287caeed109beaaca2668e2e1d6a9caf",
+    "zh:99a9ee414f5c4268e287660ce8edec2efcba1f79351f83791b64c7e5ab04f569",
+    "zh:b7cff09fe74b0eb63b5b9aa94de5b33dadbd006d6d5b9578ac476039ea20b062",
+    "zh:d4188a343ff32c0e03ff28c7e84abce0f43cad2fdbcd9046eaafc247429039ff",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,110 @@
+module "mgmt_net" {
+  source         = "./modules/network"
+  infra_provider = var.infra_provider
+  name           = "mgmt"
+  cidr           = "10.10.0.0/24"
+  gateway        = "10.10.0.1"
+}
+
+module "corp_net" {
+  source         = "./modules/network"
+  infra_provider = var.infra_provider
+  name           = "corp"
+  cidr           = "10.20.0.0/24"
+  gateway        = "10.20.0.1"
+}
+
+module "soc_net" {
+  source         = "./modules/network"
+  infra_provider = var.infra_provider
+  name           = "soc"
+  cidr           = "10.30.0.0/24"
+  gateway        = "10.30.0.1"
+}
+
+module "pfsense" {
+  source         = "./modules/vm_linux"
+  infra_provider = var.infra_provider
+  name           = "pfsense"
+  ip             = "10.10.0.2"
+  gateway        = module.mgmt_net.gateway
+  dns            = ["8.8.8.8"]
+  bridge         = module.mgmt_net.name
+  iso            = "pfsense.iso"
+  tags           = ["router"]
+}
+
+module "dc01" {
+  source         = "./modules/vm_windows"
+  infra_provider = var.infra_provider
+  name           = "dc01"
+  ip             = "10.20.0.10"
+  gateway        = module.corp_net.gateway
+  dns            = ["10.20.0.10"]
+  bridge         = module.corp_net.name
+  iso            = "windows-server.iso"
+  tags           = ["ad", "dc"]
+}
+
+module "win01" {
+  source         = "./modules/vm_windows"
+  infra_provider = var.infra_provider
+  name           = "win01"
+  ip             = "10.20.0.11"
+  gateway        = module.corp_net.gateway
+  dns            = ["10.20.0.10"]
+  bridge         = module.corp_net.name
+  iso            = "windows-10.iso"
+  tags           = ["workstation"]
+}
+
+module "lin01" {
+  source         = "./modules/vm_linux"
+  infra_provider = var.infra_provider
+  name           = "lin01"
+  ip             = "10.20.0.12"
+  gateway        = module.corp_net.gateway
+  dns            = ["10.20.0.10"]
+  bridge         = module.corp_net.name
+  iso            = "ubuntu.iso"
+  tags           = ["server"]
+}
+
+module "soc01" {
+  source         = "./modules/vm_linux"
+  infra_provider = var.infra_provider
+  name           = "soc01"
+  ip             = "10.30.0.10"
+  gateway        = module.soc_net.gateway
+  dns            = ["8.8.8.8"]
+  bridge         = module.soc_net.name
+  iso            = "ubuntu-soc.iso"
+  tags           = ["siem"]
+}
+
+locals {
+  inventory = {
+    pfsense = { name = module.pfsense.name, ip = module.pfsense.ip }
+    dc01    = { name = module.dc01.name, ip = module.dc01.ip }
+    win01   = { name = module.win01.name, ip = module.win01.ip }
+    lin01   = { name = module.lin01.name, ip = module.lin01.ip }
+    soc01   = { name = module.soc01.name, ip = module.soc01.ip }
+  }
+}
+
+resource "local_file" "inventory" {
+  filename = "${path.module}/inventory.json"
+  content  = jsonencode(local.inventory)
+}
+
+output "vm_names" {
+  value = { for k, v in local.inventory : k => v.name }
+}
+
+output "vm_ips" {
+  value = { for k, v in local.inventory : k => v.ip }
+}
+
+output "inventory_file" {
+  value = local_file.inventory.filename
+}

--- a/infra/terraform/modules/network/main.tf
+++ b/infra/terraform/modules/network/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    proxmox = { source = "bpg/proxmox" }
+    libvirt = { source = "dmacvicar/libvirt" }
+  }
+}
+
+variable "infra_provider" { type = string }
+variable "name" { type = string }
+variable "cidr" { type = string }
+variable "gateway" { type = string }
+
+resource "proxmox_virtual_environment_network_linux_bridge" "this" {
+  count     = var.infra_provider == "proxmox" ? 1 : 0
+  name      = var.name
+  node_name = "pve"
+  address   = var.cidr
+  gateway   = var.gateway
+}
+
+resource "libvirt_network" "this" {
+  count     = var.infra_provider == "libvirt" ? 1 : 0
+  name      = var.name
+  mode      = "nat"
+  domain    = var.name
+  addresses = [var.cidr]
+}
+
+output "name" {
+  value = var.name
+}
+
+output "gateway" {
+  value = var.gateway
+}

--- a/infra/terraform/modules/vm_linux/main.tf
+++ b/infra/terraform/modules/vm_linux/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_providers {
+    proxmox = { source = "bpg/proxmox" }
+    libvirt = { source = "dmacvicar/libvirt" }
+  }
+}
+
+variable "infra_provider" { type = string }
+variable "name" { type = string }
+variable "ip" { type = string }
+variable "gateway" { type = string }
+variable "dns" { type = list(string) }
+variable "bridge" { type = string }
+variable "iso" { type = string }
+variable "tags" { type = list(string) }
+
+resource "proxmox_virtual_environment_vm" "vm" {
+  count     = var.infra_provider == "proxmox" ? 1 : 0
+  name      = var.name
+  node_name = "pve"
+  tags      = var.tags
+
+  disk {
+    datastore_id = "local-lvm"
+    interface    = "scsi0"
+    size         = 20
+  }
+
+  network_device {
+    bridge = var.bridge
+  }
+
+  initialization {
+    datastore_id = "local-lvm"
+    ip_config {
+      ipv4 {
+        address = "${var.ip}/24"
+        gateway = var.gateway
+      }
+    }
+    dns {
+      servers = var.dns
+    }
+    user_account {
+      username = "ubuntu"
+      password = "password"
+    }
+  }
+}
+
+resource "libvirt_volume" "os" {
+  count  = var.infra_provider == "libvirt" ? 1 : 0
+  name   = "${var.name}.qcow2"
+  source = var.iso
+}
+
+resource "libvirt_cloudinit_disk" "init" {
+  count          = var.infra_provider == "libvirt" ? 1 : 0
+  name           = "${var.name}-cloudinit.iso"
+  user_data      = <<EOT
+#cloud-config
+hostname: ${var.name}
+ssh_pwauth: true
+chpasswd:
+  list: |
+    ubuntu:password
+  expire: False
+EOT
+  network_config = <<EOT
+version: 2
+ethernets:
+  eth0:
+    addresses: [${var.ip}/24]
+    gateway4: ${var.gateway}
+    nameservers:
+      addresses: ${jsonencode(var.dns)}
+EOT
+}
+
+resource "libvirt_domain" "vm" {
+  count  = var.infra_provider == "libvirt" ? 1 : 0
+  name   = var.name
+  memory = 2048
+  vcpu   = 2
+  disk {
+    volume_id = libvirt_volume.os[count.index].id
+  }
+  network_interface {
+    network_name = var.bridge
+  }
+  cloudinit = libvirt_cloudinit_disk.init[count.index].id
+}
+
+output "name" {
+  value = var.name
+}
+
+output "ip" {
+  value = var.ip
+}

--- a/infra/terraform/modules/vm_windows/main.tf
+++ b/infra/terraform/modules/vm_windows/main.tf
@@ -1,0 +1,95 @@
+terraform {
+  required_providers {
+    proxmox = { source = "bpg/proxmox" }
+    libvirt = { source = "dmacvicar/libvirt" }
+  }
+}
+
+variable "infra_provider" { type = string }
+variable "name" { type = string }
+variable "ip" { type = string }
+variable "gateway" { type = string }
+variable "dns" { type = list(string) }
+variable "bridge" { type = string }
+variable "iso" { type = string }
+variable "tags" { type = list(string) }
+
+resource "proxmox_virtual_environment_vm" "vm" {
+  count     = var.infra_provider == "proxmox" ? 1 : 0
+  name      = var.name
+  node_name = "pve"
+  tags      = var.tags
+
+  disk {
+    datastore_id = "local-lvm"
+    interface    = "scsi0"
+    size         = 32
+  }
+
+  network_device {
+    bridge = var.bridge
+  }
+
+  initialization {
+    datastore_id = "local-lvm"
+    ip_config {
+      ipv4 {
+        address = "${var.ip}/24"
+        gateway = var.gateway
+      }
+    }
+    dns {
+      servers = var.dns
+    }
+    user_account {
+      username = "user"
+      password = "password"
+    }
+  }
+}
+
+resource "libvirt_volume" "os" {
+  count  = var.infra_provider == "libvirt" ? 1 : 0
+  name   = "${var.name}.qcow2"
+  source = var.iso
+}
+
+resource "libvirt_cloudinit_disk" "init" {
+  count          = var.infra_provider == "libvirt" ? 1 : 0
+  name           = "${var.name}-cloudinit.iso"
+  user_data      = <<EOT
+#cloud-config
+hostname: ${var.name}
+EOT
+  network_config = <<EOT
+version: 2
+ethernets:
+  eth0:
+    addresses: [${var.ip}/24]
+    gateway4: ${var.gateway}
+    nameservers:
+      addresses: ${jsonencode(var.dns)}
+EOT
+}
+
+resource "libvirt_domain" "vm" {
+  count  = var.infra_provider == "libvirt" ? 1 : 0
+  name   = var.name
+  memory = 4096
+  vcpu   = 2
+  disk {
+    volume_id = libvirt_volume.os[count.index].id
+  }
+  network_interface {
+    network_name = var.bridge
+  }
+  cloudinit = libvirt_cloudinit_disk.init[count.index].id
+}
+
+output "name" {
+  value = var.name
+}
+
+output "ip" {
+  value = var.ip
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">=0.40.0"
+    }
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = ">=0.7.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.4.0"
+    }
+  }
+}
+
+variable "infra_provider" {
+  description = "Infrastructure provider: proxmox or libvirt"
+  type        = string
+  default     = "proxmox"
+}
+
+# Proxmox provider configuration
+provider "proxmox" {
+  endpoint  = var.proxmox_api_url
+  api_token = "${var.proxmox_token_id}=${var.proxmox_token_secret}"
+  insecure  = true
+}
+
+# Libvirt provider configuration
+provider "libvirt" {
+  uri = var.libvirt_uri
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,19 @@
+variable "proxmox_api_url" {
+  type    = string
+  default = "https://proxmox.example.com:8006/api2/json"
+}
+
+variable "proxmox_token_id" {
+  type    = string
+  default = ""
+}
+
+variable "proxmox_token_secret" {
+  type    = string
+  default = ""
+}
+
+variable "libvirt_uri" {
+  type    = string
+  default = "qemu:///system"
+}


### PR DESCRIPTION
## Summary
- add network, vm_windows, and vm_linux terraform modules with cloud-init and tag support
- support proxmox and libvirt providers via `infra_provider` flag
- generate inventory file with VM names and IPs

## Testing
- `terraform fmt -recursive`
- `terraform init`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6895bbbdcd38832cb38852b8f9d99887