### PR TITLE
feat: collect range artifacts

### DIFF
--- a/orchestrator/orchestrator/cli.py
+++ b/orchestrator/orchestrator/cli.py
@@ -5,6 +5,8 @@ import subprocess
 import typer
 import psutil
 
+from .collect import collect_artifacts
+
 app = typer.Typer(help="RangeForge orchestrator CLI.")
 
 STATE_DIR = Path("state")
@@ -82,10 +84,13 @@ def observe(
 
 
 @app.command()
-def collect(out: Path = typer.Option(Path("./artifacts"), help="Output directory")) -> None:
-    """Collect run artifacts (stub)."""
+def collect(
+    out: Path = typer.Option(Path("./artifacts"), help="Artifacts output directory"),
+) -> None:
+    """Collect run artifacts into a zip archive."""
     out.mkdir(parents=True, exist_ok=True)
-    typer.echo(f"Artifacts collected into {out}")
+    zip_path = collect_artifacts(out)
+    typer.echo(f"Artifacts archived at {zip_path}")
 
 
 @app.command()

--- a/orchestrator/orchestrator/collect.py
+++ b/orchestrator/orchestrator/collect.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import shutil
+import zipfile
+
+STATE_DIR = Path("state")
+
+
+def _collect_evtx(target_dir: Path) -> None:
+    src_root = STATE_DIR / "evtx"
+    if not src_root.exists():
+        return
+    for host_dir in src_root.iterdir():
+        if host_dir.is_dir():
+            dest = target_dir / "evtx" / host_dir.name
+            dest.mkdir(parents=True, exist_ok=True)
+            for name in ["Security.evtx", "Sysmon.evtx"]:
+                src = host_dir / name
+                if src.exists():
+                    shutil.copy2(src, dest / name)
+
+
+def _collect_winlogbeat(target_dir: Path) -> None:
+    src_root = STATE_DIR / "winlogbeat"
+    if not src_root.exists():
+        return
+    dest_root = target_dir / "winlogbeat"
+    dest_root.mkdir(parents=True, exist_ok=True)
+    for file in src_root.glob("*.ndjson"):
+        shutil.copy2(file, dest_root / file.name)
+
+
+def _collect_suricata(target_dir: Path) -> None:
+    src_root = STATE_DIR / "suricata"
+    if not src_root.exists():
+        return
+    dest_root = target_dir / "suricata"
+    dest_root.mkdir(parents=True, exist_ok=True)
+    for file in src_root.glob("*.pcap"):
+        shutil.copy2(file, dest_root / file.name)
+
+
+def collect_artifacts(out: Path) -> Path:
+    """Collect artifacts into a timestamped zip archive.
+
+    The function searches under ``STATE_DIR`` for prepared artifact files:
+    ``evtx/<host>/Security.evtx`` and ``Sysmon.evtx``, ``winlogbeat/*.ndjson``
+    and ``suricata/*.pcap``. These files are copied into a directory
+    ``out/<run_id>`` and zipped to ``out/<run_id>.zip``.
+    Returns the path to the created zip archive.
+    """
+
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    run_dir = out / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    _collect_evtx(run_dir)
+    _collect_winlogbeat(run_dir)
+    _collect_suricata(run_dir)
+
+    zip_path = out / f"{run_id}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file in run_dir.rglob("*"):
+            if file.is_file():
+                zf.write(file, arcname=file.relative_to(out))
+    return zip_path

--- a/orchestrator/tests/test_collect.py
+++ b/orchestrator/tests/test_collect.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+import zipfile
+from typer.testing import CliRunner
+import pytest
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from orchestrator import cli, collect as collector
+
+
+def test_collect_creates_zip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = tmp_path / "state"
+    (state_dir / "evtx" / "WIN01").mkdir(parents=True)
+    (state_dir / "evtx" / "WIN01" / "Security.evtx").write_text("sec")
+    (state_dir / "evtx" / "WIN01" / "Sysmon.evtx").write_text("sys")
+    (state_dir / "winlogbeat").mkdir()
+    (state_dir / "winlogbeat" / "index.ndjson").write_text("{}\n")
+    (state_dir / "suricata").mkdir()
+    (state_dir / "suricata" / "alerts.pcap").write_bytes(b"pcap")
+
+    monkeypatch.setattr(cli, "STATE_DIR", state_dir)
+    monkeypatch.setattr(collector, "STATE_DIR", state_dir)
+
+    runner = CliRunner()
+    artifacts_dir = tmp_path / "artifacts"
+    result = runner.invoke(cli.app, ["collect", "--out", str(artifacts_dir)])
+    assert result.exit_code == 0
+
+    zips = list(artifacts_dir.glob("*.zip"))
+    assert len(zips) == 1
+    zip_path = zips[0]
+    run_id = zip_path.stem
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        names = set(zf.namelist())
+    expected = {
+        f"{run_id}/evtx/WIN01/Security.evtx",
+        f"{run_id}/evtx/WIN01/Sysmon.evtx",
+        f"{run_id}/winlogbeat/index.ndjson",
+        f"{run_id}/suricata/alerts.pcap",
+    }
+    assert expected.issubset(names)


### PR DESCRIPTION
## Summary
- zip Windows logs, Winlogbeat ndjson, and Suricata pcaps into timestamped artifact
- expose artifact collection via `range collect`
- cover artifact packaging with tests

## Testing
- `pre-commit run ruff --files orchestrator/orchestrator/collect.py orchestrator/orchestrator/cli.py orchestrator/tests/test_collect.py`
- `pre-commit run mypy --files orchestrator/orchestrator/collect.py orchestrator/orchestrator/cli.py orchestrator/tests/test_collect.py`
- `pytest orchestrator/tests/test_collect.py`


------
https://chatgpt.com/codex/tasks/task_e_68960a6763dc832c8c21cd5c8c260fe8